### PR TITLE
Adding the ability to hide the passcode during disarm

### DIFF
--- a/alarm.yaml
+++ b/alarm.yaml
@@ -15,6 +15,7 @@ clock: True  #[Optional] - False by default. True enables a clock in the center 
 perimeter_mode: True #[Optional] - False by default. True enables perimeter mode, this could be known as 'Day Mode' i.e. only arm the doors whilst there is someone using all floors
 weather: True #[Optional] - False by Default. Allows a weather summary to be displayed on the status bar. Dark Sky weather component must be enabled with the name sensor.dark_sky_summary
 #settings: True #[NOT YET IMPLEMENTED, OPTIONAL] True/False. Enables a settings mode which allows you to define certain settings in the UI without the need to restart HA after certain config changes. This will be used for fluid settings such as enabling/disabling the screensaver mode once implmented. NOTE for this to work you will need to create a directory within your HA config directory named 'alarm_settings' this is where the settings file will be managed. Also ensure you have the appropriate permissions/ownership for the HA user to create/amend the file.
+hide_passcode: True #[OPTIONAL] - True by default. This is a security feature when enabled hides the passcode while entering disarm code.
 hide_sidebar: True #[OPTIONAL] - False by default. This is a security feature when enabled hides the HA sidebar when the alarm is armed. The sidebar re-appears when the alarm is disarmed.
 #hide_all_sensors: True #[NOT YET IMPLEMENTED, Optional] - False by default. Setting this to True hides the 'All Sensors' box which displays every sensor when in disarmed mode.
 

--- a/custom_components/alarm_control_panel/bwalarm.py
+++ b/custom_components/alarm_control_panel/bwalarm.py
@@ -82,6 +82,7 @@ CONF_CLOCK                   = 'clock'
 CONF_WEATHER                 = 'weather'
 CONF_SETTINGS                = 'settings'
 CONF_HIDE_ALL_SENSORS        = 'hide_all_sensors'
+CONF_HIDE_PASSCODE           = 'hide_passcode'
 CONF_HIDE_SIDEBAR            = 'hide_sidebar'
 
 #//-----------------------COLOURS------------------------------------
@@ -141,7 +142,8 @@ PLATFORM_SCHEMA = vol.Schema({
     vol.Optional(CONF_CLOCK, default=False):               cv.boolean,    # DIsplay clock on panel
     vol.Optional(CONF_WEATHER, default=False):             cv.boolean,    # DIsplay weather on panel
     vol.Optional(CONF_HIDE_ALL_SENSORS, default=False):    cv.boolean,    # Show all sensors in group?
-    vol.Optional(CONF_HIDE_SIDEBAR, default=False):       cv.boolean,    # Show all sensors in group?
+    vol.Optional(CONF_HIDE_PASSCODE, default=True):        cv.boolean,    # Show passcode entry during disarm?
+    vol.Optional(CONF_HIDE_SIDEBAR, default=False):        cv.boolean,    # Show all sensors in group?
     #--------------------------PASSWORD ATTEMPTS--------------------------
     vol.Optional(CONF_PASSCODE_ATTEMPTS, default=-1):         vol.All(vol.Coerce(int), vol.Range(min=-1)),
     vol.Optional(CONF_PASSCODE_ATTEMPTS_TIMEOUT, default=-1): vol.All(vol.Coerce(int), vol.Range(min=-1)),
@@ -225,7 +227,8 @@ class BWAlarm(alarm.AlarmControlPanel):
         self._perimeter_mode         = config[CONF_PERIMETER_MODE]
         self._settings               = config[CONF_SETTINGS]
         self._hide_all_sensors       = config[CONF_HIDE_ALL_SENSORS]
-        self._hide_sidebar          = config[CONF_HIDE_SIDEBAR]
+        self._hide_passcode          = config[CONF_HIDE_PASSCODE]
+        self._hide_sidebar           = config[CONF_HIDE_SIDEBAR]
         self._clock                  = config[CONF_CLOCK]
         self._weather                = config[CONF_WEATHER]
 
@@ -298,7 +301,8 @@ class BWAlarm(alarm.AlarmControlPanel):
             'settings':           self._settings,
             'settings_list':      self._settings_list,
             'hide_all_sensors':   self._hide_all_sensors,
-            'hide_sidebar':      self._hide_sidebar,
+            'hide_passcode':      self._hide_passcode,
+            'hide_sidebar':       self._hide_sidebar,
             'panel_locked':       self._panel_locked,
             'passcode_attempt_timeout': self._passcodeAttemptTimeout,
             'supported_statuses_on': self._supported_statuses_on,

--- a/panels/alarm.html
+++ b/panels/alarm.html
@@ -97,7 +97,7 @@
 									<iron-label>PANEL LOCKED OUT</iron-label>
 								</template>
 								<template is='dom-if' if='[[!alarm.attributes.panel_locked]]'> 
-									<iron-label>[[computeLabel(alarm.state)]] Mode Activated&nbsp;<iron-icon icon='mdi:key'></iron-icon>&nbsp;&nbsp;[[code]]</iron-label>
+									<iron-label>[[computeLabel(alarm.state)]] Mode Activated&nbsp;<iron-icon icon='mdi:key'></iron-icon>&nbsp;&nbsp;[[display_code]]</iron-label>
 								</template>
 							</div>
 							<div id='codepanel' class$='horizontal layout center-justified {{getClass(panel_locked)}}'>
@@ -478,11 +478,17 @@ computeLabel: function (state) {
    	ev.stopPropagation();
    	var digit = ev.target.getAttribute('data-digit');
    	this.code = this.code + digit;
+   	var display_digit = digit;
+   	if (this.alarm.attributes.hide_passcode) {
+   	  display_digit = '*';
+   	}
+   	this.display_code = this.display_code + display_digit;
       //console.log(this.code);
   },
   callclearcode: function(ev) {
   	ev.stopPropagation();
   	this.code = '';
+  	this.display_code = '';
       //console.log('Code Cleared: ' + this.code);
   },
   callService: function(ev) {
@@ -497,6 +503,7 @@ computeLabel: function (state) {
       } else { //No open sensors or another service call
       	this.hass.callService('alarm_control_panel', call, {'entity_id': this.alarm.entityId, 'code': this.code});
       	this.code = '';
+      	this.display_code = '';
       }
   },
   checkOpenSensors: function(call) {


### PR DESCRIPTION
This feature enhancement adds the ability to disable the passcode
from being echoed out to the screen. Using the `hide_passcode`
attribute in the `alarm.yaml` setting this feature can be enabled
or disabled; default is enabled (hiding passcode).