### PR TITLE
Update panel_custom.yaml

### DIFF
--- a/panel_custom.yaml
+++ b/panel_custom.yaml
@@ -1,5 +1,5 @@
   - name: alarm
     sidebar_title: Alarm
-    sidebar_icon: mdi:security-home
+    sidebar_icon: mdi:shield-home
     config:
       alarmid: alarm_control_panel.house


### PR DESCRIPTION
From 0.87.0 supported MDI library v.3.3.92 (https://cdn.materialdesignicons.com/3.3.92/) has mdi:security-home renamed to mdi:shield-home