### PR TITLE
2 bugfixes

### DIFF
--- a/panels/alarm.html
+++ b/panels/alarm.html
@@ -2062,7 +2062,7 @@
 
       entityTapped(ev){
         ev.stopPropagation();
-        this.fire('hass-more-info', { entityId: ev.target.getAttribute('data-entity')});
+        this.fire('hass-more-info', { entity_id: ev.target.getAttribute('data-entity')});
       }
 
       //Monitors the alarm status for any changes

--- a/panels/alarm.html
+++ b/panels/alarm.html
@@ -1465,7 +1465,7 @@
 
           this.controls = this.$.controls;
 
-          if (this.alarm.attributes.hide_sidebar == true)  this.closeSidebar();
+          if (this.alarm.attributes.hide_sidebar == true)  this.closeSidebar;
 
           //Determine screensize and set appropriate controls
           this.setupUI();
@@ -2056,7 +2056,7 @@
 
       // Close the sidebar if alarm is set and the option is enabled
       closeSidebar(instance){
-        if (instance) if (instance.alarm.state != 'disarmed')
+        if (instance.alarm.state != 'disarmed')
           instance.fire('hass-close-menu');
       }
 
@@ -2378,7 +2378,7 @@
 
       //Call one of the alarm services
       alarmService(call){
-        this.hass.callService('alarm_control_panel', call, {'entity_id': this.alarm.entityId, 'code': this.code });
+        this.hass.callService('alarm_control_panel', call, {'entity_id': this.alarm.entity_id, 'code': this.code });
       }
 
       //Restart Home Assistant


### PR DESCRIPTION
1. Fixed Uncaught TypeError: Cannot read property 'state' of undefined in closeSidebar
2. Fixed typo (entityId instead of entity_id) that caused the following warning:
Not passing an entity ID to a service to target all entities is deprecated. Update your call to alarm_control_panel.alarm_arm_home to be instead: entity_id: all