### PR TITLE
Return keypad to Lovelace card

### DIFF
--- a/custom_components/alarm_control_panel/bwalarm.py
+++ b/custom_components/alarm_control_panel/bwalarm.py
@@ -686,7 +686,7 @@ class BWAlarm(alarm.AlarmControlPanel):
     @property
     def code_format(self):
         """One or more characters."""
-        return None if self._code is None else 'number'
+        return None if ((self._code is None) or (self._state == STATE_ALARM_DISARMED)) else 'number'
 
     def alarm_disarm(self, code=None):
         #If the provided code matches the panic alarm then deactivate the alarm but set the state of the panic mode to active.

--- a/custom_components/alarm_control_panel/bwalarm.py
+++ b/custom_components/alarm_control_panel/bwalarm.py
@@ -686,7 +686,7 @@ class BWAlarm(alarm.AlarmControlPanel):
     @property
     def code_format(self):
         """One or more characters."""
-        return None if self._code is None else '.+'
+        return None if self._code is None else 'number'
 
     def alarm_disarm(self, code=None):
         #If the provided code matches the panic alarm then deactivate the alarm but set the state of the panic mode to active.

--- a/custom_components/alarm_control_panel/bwalarm.py
+++ b/custom_components/alarm_control_panel/bwalarm.py
@@ -685,8 +685,8 @@ class BWAlarm(alarm.AlarmControlPanel):
 
     @property
     def code_format(self):
-        """One or more characters."""
-        return None if ((self._code is None) or (self._state == STATE_ALARM_DISARMED)) else 'number'
+        """One or more digits."""
+        return None if ((self._code is None) or (self._state == STATE_ALARM_DISARMED)) else alarm.FORMAT_NUMBER
 
     def alarm_disarm(self, code=None):
         #If the provided code matches the panic alarm then deactivate the alarm but set the state of the panic mode to active.


### PR DESCRIPTION
Fix of Lovelace card keypad missing.
The current edition of this fix supports only numeric codes and not text, don't think that's applicable to this alarm anyway.
That hides keypad if alarm is disarmed, you will only see the keypad in one of armed states.